### PR TITLE
Update domain.te

### DIFF
--- a/prebuilts/api/33.0/public/domain.te
+++ b/prebuilts/api/33.0/public/domain.te
@@ -386,6 +386,7 @@ neverallow {
   -init
   -ueventd
   -vold
+  -recovery 
 } self:global_capability_class_set mknod;
 
 # No process can map low memory (< CONFIG_LSM_MMAP_MIN_ADDR).


### PR DESCRIPTION
Fixing the error

```
FAILED: /mnt/data/sos13/out/soong/.intermediates/system/sepolicy/sepolicy_freeze_test/freeze_test diff -r -q -x bug_map system/sepolicy/public system/sepolicy/prebuilts/api/33.0/public && diff -r -q -x bug_map system/sepolicy/private system/sep olicy/prebuilts/api/33.0/private && touch /mnt/data/sos13/out/soong/.intermediates/system/sepolicy/sepolicy_freeze_test/freeze_test # hash of inpu t list: 29c7d44b35db73f8dfe2664076b372f9fb2742b13d5a0299968a45f3c6f8003e Files system/sepolicy/public/domain.te and system/sepolicy/prebuilts/api/33.0/public/domain.te differ 06:23:51 ninja failed with: exit status 1

#### failed to build some targets (53:10 (mm:ss)) ####
```