### PR TITLE
Update system_app.te

### DIFF
--- a/prebuilts/api/33.0/private/system_app.te
+++ b/prebuilts/api/33.0/private/system_app.te
@@ -177,7 +177,7 @@ get_prop(system_app, oem_unlock_prop)
 # Allow system apps to act as Perfetto producers.
 perfetto_producer(system_app)
 
-#selinux status 
+#selinux status
 allow system_app selinuxfs:file r_file_perms;
 
 # Allow performance profiling by the platform itself.

--- a/prebuilts/api/33.0/private/system_app.te
+++ b/prebuilts/api/33.0/private/system_app.te
@@ -177,6 +177,9 @@ get_prop(system_app, oem_unlock_prop)
 # Allow system apps to act as Perfetto producers.
 perfetto_producer(system_app)
 
+#selinux status 
+allow system_app selinuxfs:file r_file_perms;
+
 # Allow performance profiling by the platform itself.
 can_profile_heap(system_app)
 can_profile_perf(system_app)


### PR DESCRIPTION
To fix the error

```
[0% 223/88520] //system/sepolicy:sepolicy_freeze_test sepolicy_freeze_test
FAILED: /mnt/data/sos13/out/soong/.intermediates/system/sepolicy/sepolicy_freeze_test/freeze_test diff -r -q -x bug_map system/sepolicy/public system/sepolicy/prebuilts/api/33.0/public && diff -r -q -x bug_map system/sepolicy/private system/sep olicy/prebuilts/api/33.0/private && touch /mnt/data/sos13/out/soong/.intermediates/system/sepolicy/sepolicy_freeze_test/freeze_test # hash of inpu t list: 29c7d44b35db73f8dfe2664076b372f9fb2742b13d5a0299968a45f3c6f8003e Files system/sepolicy/private/system_app.te and system/sepolicy/prebuilts/api/33.0/private/system_app.te differ 06:46:58 ninja failed with: exit status 1

#### failed to build some targets (01:51 (mm:ss)) ####
```